### PR TITLE
Add support for promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ var zlib = require('zlib');
 var path = require('path');
 var URL = require('url');
 var fs = require('fs');
+var Promise = require('node-promise').Promise;
 
 /**
  * Define form mime type
@@ -335,11 +336,17 @@ var Unirest = function (method, uri, headers, body, callback) {
        * @param  {Function} callback
        * @return {Object}
        */
-      end: function (callback) {
+      end: function (cb) {
         var Request;
         var header;
         var parts;
         var form;
+        var promise = new Promise();
+
+        function callback(result) {
+          if (cb) return cb(result);
+          promise.resolve(result);
+        }
 
         function handleRequestResponse (error, response, body) {
           var result = {};
@@ -578,6 +585,9 @@ var Unirest = function (method, uri, headers, body, callback) {
         Request = Unirest.request($this.options, handleRequestResponse);
         Request.on('response', handleGZIPResponse);
 
+        Request.exec = function() {
+          return promise;
+        }
         if ($this._multipart.length && $this._stream)
           handleFormData(Request.form());
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "form-data": "^0.2.0",
     "mime": "~1.2.11",
     "node-promise": "^0.5.12",
-    "promise": "^7.0.3",
     "request": "~2.51.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "dependencies": {
     "form-data": "^0.2.0",
     "mime": "~1.2.11",
+    "node-promise": "^0.5.12",
+    "promise": "^7.0.3",
     "request": "~2.51.0"
   },
   "devDependencies": {


### PR DESCRIPTION
usage `yield unirest.get('https://google/com').end().exec()`

appended an `exec()` method to `Request`, thus will return a Promise object.
