### PR TITLE
Update to mime 1.4.1 due to a security advisory: https://nodesecurity.io/advisories/535

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "form-data": "^0.2.0",
-    "mime": "~1.3.4",
+    "mime": "~1.4.1",
     "request": "~2.74.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Removes a security advisory warning and fixes https://github.com/Mashape/unirest-nodejs/issues/111