### PR TITLE
Implement Promises and async/await

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,27 @@ unirest.get('http://mockbin.com/request').end(function (response) {
 });
 ```
 
+#### Request.then(Function callback)
+
+Invokes `Request.end` and returns a Promise chain.
+
+```js
+unirest.get('http://mockbin.com/request').then(function (response) {
+  ...
+});
+```
+
+Implements the promise chain for async/await
+
+```js
+... some async function
+
+var response = await unirest.get('http://mockbin.com/request');
+
+...
+```
+
+
 ## Request Aliases
 
 #### Request.set

--- a/index.js
+++ b/index.js
@@ -354,6 +354,26 @@ var Unirest = function (method, uri, headers, body, callback) {
       },
 
       /**
+       * Proxies the call to end. This adds support for using promises as well as async/await.
+       * 
+       * @param  {Function} callback
+       * @return {Promise}
+      **/ 
+      then: function (callback) {
+        var self = this;
+        return new Promise(function (resolve, reject) {
+          self.end(function (result) {
+            try {
+              var returnValue = callback(result);
+              resolve(returnValue);
+            } catch (err) {
+              reject(err);
+            }
+          });
+        });
+      },
+
+      /**
        * Sends HTTP Request and awaits Response finalization. Request compression and Response decompression occurs here.
        * Upon HTTP Response post-processing occurs and invokes `callback` with a single argument, the `[Response](#response)` object.
        *

--- a/tests/async/async-test.js
+++ b/tests/async/async-test.js
@@ -1,0 +1,78 @@
+var fs = require('fs')
+var should = require('should')
+var unirest = require('../../index')
+var express = require('express')
+var bodyParser = require('body-parser')
+
+// Mock Server
+var app = express()
+var server
+
+
+describe('Unirest', function () {
+  describe('Async Await', function () {
+    var host, port, url
+    var fixture = {
+      message: 'some message under a json object'
+    }
+
+    before(function(done) {
+      app.use(bodyParser.json({
+        type: 'application/vnd.api+json'
+      }))
+
+      app.get('/', function handleRoot(req, res) {
+        res.set('content-type', 'application/vnd.api+json')
+        res.send(fixture)
+      })
+
+      server = app.listen(3000, function liftServer () {
+        host = server.address().address
+        port = server.address().port
+        url = 'http://localhost:3000'
+        done()
+      })
+    })
+
+    after(function afterAll (done) {
+      server.close(function closeCallback () {
+        done()
+      })
+    })
+
+    it('should support async/await', async function jsonTest (done) {
+      var response = await unirest.get(url).type('json')
+      response.body.should.eql(fixture)
+      done()
+    })
+
+    it('should support async/await and maintain promise chains', async function jsonTest () {
+      var boolean = await unirest.get(url).type('json').then(function (res) {
+        return true
+      })
+      should(boolean).eql(true)
+      return true
+    })
+
+    it('should support async/await and errors should be handled in the catch statement', async function jsonTest (done) {
+      var boolean = await unirest.get(url).type('json').then(function endJsonTest (response) {
+        var myObject = {};
+        myObject.undefinedIsNotAFunction();
+      }).catch(function (err) {
+        done()
+      })
+    })
+
+    it('should support async/await and errors can be returned to the left hand assignment', async function jsonTest (done) {
+      var oops = await unirest.get(url).type('json').then(function endJsonTest (response) {
+        var myObject = {};
+        myObject.undefinedIsNotAFunction();
+      }).catch(function (err) {
+        return 'oops'
+      })
+      oops.should.eql('oops')
+      done()
+    })
+
+  })
+})

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -3,10 +3,20 @@ var should = require('should')
 var unirest = require('../index')
 var express = require('express')
 var bodyParser = require('body-parser')
+var vm = require('vm')
 
 // Mock Server
 var app = express()
 var server
+
+// Check for async/await
+var asyncAwait = true
+try {
+  new vm.Script('(async () => ({}))()');
+} catch (e) {
+  asyncAwait = false
+}
+
 
 describe('Unirest', function () {
   describe('Cookie Jar', function () {
@@ -384,4 +394,65 @@ describe('Unirest', function () {
         })
     })
   })
+
+  describe('Using then', function () {
+    var host, port, url
+    var fixture = {
+      message: 'some message under a json object'
+    }
+
+    before(function(done) {
+      app.use(bodyParser.json({
+        type: 'application/vnd.api+json'
+      }))
+
+      app.get('/', function handleRoot(req, res) {
+        res.set('content-type', 'application/vnd.api+json')
+        res.send(fixture)
+      })
+
+      server = app.listen(3000, function liftServer () {
+        host = server.address().address
+        port = server.address().port
+        url = 'http://localhost:3000'
+        done()
+      })
+    })
+
+    after(function afterAll (done) {
+      server.close(function closeCallback () {
+        done()
+      })
+    })
+
+    it('should get a json from the main route', function jsonTest () {
+      return unirest.get(url).type('json').then(function endJsonTest (response) {
+        response.body.should.eql(fixture)
+        return  true;
+      })
+    })
+
+    it('should maintain the promise chain', function jsonTest () {
+      return unirest.get(url).type('json').then(function endJsonTest (response) {
+        return response
+      }).then(function endJsonTest (response) {
+        response.body.should.eql(fixture)
+        return fixture
+      })
+    })
+
+    it('errors should be handled in the catch statement', function jsonTest (done) {
+      unirest.get(url).type('json').then(function endJsonTest (response) {
+        var myObject = {};
+        myObject.undefinedIsNotAFunction();
+      }).catch(function (err) {
+        done();
+      })
+    })
+  })
+
+  if (asyncAwait) {
+    require('./async/async-test')
+  }
+
 })


### PR DESCRIPTION
This pull request allows using promises in unirest. By default, it also implements async/await.

The idea is that by defining `then` and returning a promise from it will also enable async/await.

Invoking `then` returns a proper promise chain with the callback try/catch wrapped so that errors that occur inside the callback can get handled by the catch method of the promise chain.