### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ var fs = require('fs')
  */
 mime.define({
   'application/x-www-form-urlencoded': ['form', 'urlencoded', 'form-data']
-})
+},true)
 
 /**
  * Initialize our Rest Container


### PR DESCRIPTION
This is to support the higer versoin of mime from 2.* .This fix is required to avoid the error of mandate true on the mine on the retries

To avoid the below error on retries callback

Error: Attempt to change mapping for "form" extension from "application/x-www-form-urlencoded" to "application/x-www-form-urlencoded". Pass `force=true` to allow this, otherwise remove "form" from the list of extensions for "application/x-www-form-urlencoded".
    at Mime.define (/home/user/projects/mytest/node_modules/mime/Mime.js:32:17)
